### PR TITLE
Case mismatch between loaded and declared class names

### DIFF
--- a/src/Mkusher/Date/Distance.php
+++ b/src/Mkusher/Date/Distance.php
@@ -7,7 +7,7 @@
  * Created: 18/02/2014 9:49 PM
  */
 
-namespace MKusher\Date;
+namespace Mkusher\Date;
 
 use \DateTime;
 use \Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToTimestampTransformer;


### PR DESCRIPTION
After upgrading to Symfony 2.7

An exception has been thrown during the rendering of a template ("Case mismatch between loaded and declared class names: Mkusher\Date\Distance vs MKusher\Date\Distance") in index.html.twig at line 19.

``` twig
.createdAt | ago }}
```
